### PR TITLE
Add theme activation action sheet

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeActivationBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeActivationBottomSheetFragment.kt
@@ -1,0 +1,37 @@
+package org.wordpress.android.ui.themes
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.View.INVISIBLE
+import android.view.View.VISIBLE
+import android.view.ViewGroup
+import androidx.annotation.NonNull
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import org.wordpress.android.R
+import org.wordpress.android.databinding.ThemeActivationBottomSheetBinding
+
+class ThemeActivationBottomSheetFragment : BottomSheetDialogFragment() {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.theme_activation_bottom_sheet, container)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        with(ThemeActivationBottomSheetBinding.bind(view)) {
+            closeButton.setOnClickListener { dismiss() }
+            useThemeLayoutLl.setOnClickListener { toggleSelection(useThemeCheckIv, keepCurrentCheckIv) }
+            keepCurrentLayoutLl.setOnClickListener { toggleSelection(keepCurrentCheckIv, useThemeCheckIv) }
+            previewThemeButton.setOnClickListener { /*TODO*/ }
+            activateThemeButton.setOnClickListener { /*TODO*/ }
+        }
+    }
+
+    private fun toggleSelection(@NonNull viewTapped: View, vararg otherView: View) {
+        if (viewTapped.visibility == INVISIBLE) {
+            viewTapped.visibility = VISIBLE
+            otherView.forEach { it.visibility = INVISIBLE }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -328,6 +328,8 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
     }
 
     private void activateTheme(String themeId) {
+        // TODO Link theme activation action sheet
+
         if (!mSite.isUsingWpComRestApi()) {
             AppLog.i(T.THEMES, "Theme activation requires a site using WP.com REST API. Aborting request.");
             return;

--- a/WordPress/src/main/res/drawable/bg_oval_dark_gray_close_action_sheet_pressed.xml
+++ b/WordPress/src/main/res/drawable/bg_oval_dark_gray_close_action_sheet_pressed.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/gray_50"/>
+</shape>

--- a/WordPress/src/main/res/drawable/bg_oval_gray_action_sheet_close.xml
+++ b/WordPress/src/main/res/drawable/bg_oval_gray_action_sheet_close.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/gray_0"/>
+</shape>

--- a/WordPress/src/main/res/drawable/close_action_sheet_circle_selector.xml
+++ b/WordPress/src/main/res/drawable/close_action_sheet_circle_selector.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/bg_oval_dark_gray_close_action_sheet_pressed" android:state_pressed="true"/>
+    <item android:drawable="@drawable/bg_oval_dark_gray_close_action_sheet_pressed" android:state_selected="true"/>
+    <item android:drawable="@drawable/bg_oval_gray_action_sheet_close"/>
+</selector>

--- a/WordPress/src/main/res/drawable/ic_tick_vector_blue.xml
+++ b/WordPress/src/main/res/drawable/ic_tick_vector_blue.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#3C5ACB"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M9,16.2L4.8,12l-1.4,1.4L9,19 21,7l-1.4,-1.4L9,16.2z"/>
+</vector>

--- a/WordPress/src/main/res/layout/theme_activation_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout/theme_activation_bottom_sheet.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include
+        android:id="@+id/bottom_sheet_handle"
+        layout="@layout/bottom_sheet_handle_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <ImageButton
+        android:id="@+id/close_button"
+        android:layout_width="@dimen/theme_activation_bottom_sheet_close_button_size"
+        android:layout_height="@dimen/theme_activation_bottom_sheet_close_button_size"
+        android:layout_alignParentEnd="true"
+        android:layout_below="@id/bottom_sheet_handle"
+        android:layout_margin="@dimen/theme_activation_bottom_sheet_margin_16dp"
+        android:background="@drawable/close_action_sheet_circle_selector"
+        android:contentDescription="@string/label_close_button"
+        android:cropToPadding="true"
+        android:padding="@dimen/theme_activation_bottom_sheet_close_button_padding"
+        android:src="@drawable/ic_close_black_24dp"
+        android:tint="@color/gray_30" />
+
+    <TextView
+        android:id="@+id/theme_name_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/close_button"
+        android:layout_centerHorizontal="true"
+        android:fontFamily="@font/libre_baskerville"
+        android:text="Theme Name"
+        android:textColor="@color/black"
+        android:textSize="@dimen/theme_activation_bottom_sheet_title_text_size"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/info_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/theme_name_tv"
+        android:layout_marginEnd="@dimen/theme_activation_bottom_sheet_margin_32dp"
+        android:layout_marginStart="@dimen/theme_activation_bottom_sheet_margin_32dp"
+        android:layout_marginTop="@dimen/theme_activation_bottom_sheet_margin_16dp"
+        android:gravity="center"
+        android:text="@string/theme_activation_bottom_sheet_info"
+        android:textSize="@dimen/theme_activation_bottom_sheet_text_size" />
+
+    <RelativeLayout
+        android:id="@+id/use_theme_layout_ll"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/info_tv"
+        android:layout_marginEnd="@dimen/theme_activation_bottom_sheet_margin_16dp"
+        android:layout_marginStart="@dimen/theme_activation_bottom_sheet_margin_16dp"
+        android:layout_marginTop="@dimen/theme_activation_bottom_sheet_margin_32dp">
+
+        <ImageView
+            android:id="@+id/use_theme_check_iv"
+            android:layout_width="@dimen/theme_activation_bottom_sheet_selector_size"
+            android:layout_height="@dimen/theme_activation_bottom_sheet_selector_size"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:contentDescription="@string/theme_activation_bottom_sheet_selected_description"
+            android:src="@drawable/ic_tick_vector_blue"
+            android:visibility="invisible" />
+
+        <TextView
+            android:id="@+id/use_theme_layout_sub_text_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/use_theme_layout_main_text_tv"
+            android:text="@string/theme_activation_use_theme_layout_sub_text"
+            android:textSize="@dimen/theme_activation_bottom_sheet_text_size_small" />
+
+        <TextView
+            android:id="@+id/use_theme_layout_main_text_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/theme_activation_use_theme_layout_main_text"
+            android:textColor="@color/black"
+            android:textSize="@dimen/theme_activation_bottom_sheet_text_size" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/theme_activation_bottom_sheet_divider_height"
+            android:layout_below="@+id/use_theme_layout_sub_text_tv"
+            android:layout_marginTop="@dimen/theme_activation_bottom_sheet_margin_8dp"
+            android:background="@color/gray_5" />
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/keep_current_layout_ll"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/use_theme_layout_ll"
+        android:layout_marginEnd="@dimen/theme_activation_bottom_sheet_margin_16dp"
+        android:layout_marginStart="@dimen/theme_activation_bottom_sheet_margin_16dp"
+        android:layout_marginTop="@dimen/theme_activation_bottom_sheet_margin_8dp">
+
+        <ImageView
+            android:id="@+id/keep_current_check_iv"
+            android:layout_width="@dimen/theme_activation_bottom_sheet_selector_size"
+            android:layout_height="@dimen/theme_activation_bottom_sheet_selector_size"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:contentDescription="@string/theme_activation_bottom_sheet_selected_description"
+            android:src="@drawable/ic_tick_vector_blue" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="30dp"
+            android:layout_alignParentStart="true"
+            android:layout_toStartOf="@id/keep_current_check_iv"
+            android:gravity="center_vertical"
+            android:text="@string/theme_activation_keep_current_layout_main_text"
+            android:textColor="@color/black"
+            android:textSize="@dimen/theme_activation_bottom_sheet_text_size" />
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="70dp"
+        android:layout_below="@id/keep_current_layout_ll"
+        android:layout_marginTop="@dimen/theme_activation_bottom_sheet_margin_16dp"
+        android:background="@color/gray_0">
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/theme_activation_bottom_sheet_divider_height"
+            android:background="@color/gray_5" />
+
+        <LinearLayout
+            android:id="@+id/action_sheet_buttons_ll"
+            android:layout_width="match_parent"
+            android:layout_height="55dp"
+            android:layout_marginBottom="@dimen/theme_activation_bottom_sheet_margin_8dp"
+            android:layout_marginEnd="@dimen/theme_activation_bottom_sheet_margin_16dp"
+            android:layout_marginStart="@dimen/theme_activation_bottom_sheet_margin_16dp"
+            android:layout_marginTop="@dimen/theme_activation_bottom_sheet_margin_8dp"
+            android:orientation="horizontal">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/preview_theme_button"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:text="@string/theme_activation_bottom_sheet_preview_button_label"
+                android:textAllCaps="false"
+                android:textColor="@color/gray_50"
+                app:cornerRadius="8dp" />
+
+            <Space
+                android:layout_width="@dimen/theme_activation_bottom_sheet_margin_16dp"
+                android:layout_height="match_parent" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/activate_theme_button"
+                style="@style/Widget.MaterialComponents.Button"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:backgroundTint="@color/accent"
+                android:text="@string/theme_activation_bottom_sheet_activate_button_label"
+                android:textAllCaps="false"
+                android:textColor="@color/white"
+                app:cornerRadius="8dp" />
+        </LinearLayout>
+    </RelativeLayout>
+</RelativeLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -671,4 +671,16 @@
 
     <dimen name="blogging_reminders_days_top_margin">42dp</dimen>
     <dimen name="blogging_reminders_days_middle_margin">7dp</dimen>
+
+    <!-- theme activation bottom sheet -->
+    <dimen name="theme_activation_bottom_sheet_close_button_size">30dp</dimen>
+    <dimen name="theme_activation_bottom_sheet_selector_size">20dp</dimen>
+    <dimen name="theme_activation_bottom_sheet_divider_height">1dp</dimen>
+    <dimen name="theme_activation_bottom_sheet_margin_8dp">8dp</dimen>
+    <dimen name="theme_activation_bottom_sheet_margin_16dp">16dp</dimen>
+    <dimen name="theme_activation_bottom_sheet_margin_32dp">32dp</dimen>
+    <dimen name="theme_activation_bottom_sheet_close_button_padding">10dp</dimen>
+    <dimen name="theme_activation_bottom_sheet_title_text_size">23sp</dimen>
+    <dimen name="theme_activation_bottom_sheet_text_size">16sp</dimen>
+    <dimen name="theme_activation_bottom_sheet_text_size_small">14sp</dimen>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3691,4 +3691,13 @@
     <string name="blogging_reminders_select_days_message">You can update this anytime</string>
     <string name="blogging_reminders_tip">Tip</string>
     <string name="blogging_reminders_tip_message">Posting regularly can help keep your readers engaged, and attract new visitors to your site.</string>
+
+    <!--  theme activation bottom sheet  -->
+    <string name="theme_activation_bottom_sheet_info">%1$s comes with a tailored home page or you can create your own</string>
+    <string name="theme_activation_bottom_sheet_selected_description">Selected</string>
+    <string name="theme_activation_use_theme_layout_main_text">Use %1$s\'s homepage layout</string>
+    <string name="theme_activation_use_theme_layout_sub_text">Saves the current homepage as a draft</string>
+    <string name="theme_activation_keep_current_layout_main_text">Keep current homepage layout</string>
+    <string name="theme_activation_bottom_sheet_preview_button_label">Preview</string>
+    <string name="theme_activation_bottom_sheet_activate_button_label">Activate</string>
 </resources>


### PR DESCRIPTION
Part of #15014

Fixes #
This PR adds an action sheet that enables the user to keep their homepage layout when activating a theme. This action sheet is not linked to any control in this PR right now.

To test:
Cannot be tested stand-alone. 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
